### PR TITLE
add daily revenue endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
@@ -2,11 +2,13 @@ package com.parkingplus.parkinghistory
 
 import com.parkingplus.vehicles.VehicleService
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/parking-history")
@@ -73,5 +75,14 @@ class ParkingHistoryController(
     @GetMapping("/parking-space/{parkingSpaceId}")
     fun getParkingHistoryByParkingSpace(@PathVariable parkingSpaceId: String): ResponseEntity<List<ParkingHistoryDTO>> {
         return ResponseEntity.ok(parkingHistoryService.getParkingHistoryByParkingSpace(parkingSpaceId))
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/daily-revenue")
+    fun getDailyRevenue(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
+    ): ResponseEntity<Double> {
+        val revenue = parkingHistoryService.getDailyRevenue(date)
+        return ResponseEntity.ok(revenue)
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -1,6 +1,8 @@
 package com.parkingplus.parkinghistory
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -11,5 +13,9 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
     fun findByVehicleLicensePlateAndEndTimeIsNull(licensePlate: String): ParkingHistoryEntity?
     fun existsByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): Boolean
     fun findAllByParkingSpaceId(parkingSpaceId: String): List<ParkingHistoryEntity>
-    fun findAllByEndTimeBetween(start: LocalDateTime, end: LocalDateTime): List<ParkingHistoryEntity>
+    @Query("SELECT COALESCE(SUM(p.price), 0.0) FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end")
+    fun sumPriceByEndTimeBetween(
+        @Param("start") start: LocalDateTime,
+        @Param("end") end: LocalDateTime
+    ): Double
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -2,6 +2,7 @@ package com.parkingplus.parkinghistory
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
@@ -10,4 +11,5 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
     fun findByVehicleLicensePlateAndEndTimeIsNull(licensePlate: String): ParkingHistoryEntity?
     fun existsByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): Boolean
     fun findAllByParkingSpaceId(parkingSpaceId: String): List<ParkingHistoryEntity>
+    fun findAllByEndTimeBetween(start: LocalDateTime, end: LocalDateTime): List<ParkingHistoryEntity>
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -4,7 +4,9 @@ import com.parkingplus.parkingspaces.ParkingSpaceRepository
 import com.parkingplus.vehicles.VehicleRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class ParkingHistoryService(
@@ -82,5 +84,15 @@ class ParkingHistoryService(
     @Transactional
     fun deleteAllParkingHistory() {
         parkingHistoryRepository.deleteAll()
+    }
+
+    @Transactional(readOnly = true)
+    fun getDailyRevenue(date: LocalDate): Double {
+        val startOfDay = date.atStartOfDay()
+        val endOfDay = date.atTime(LocalTime.MAX)
+
+        val parkings = parkingHistoryRepository.findAllByEndTimeBetween(startOfDay, endOfDay)
+
+        return parkings.sumOf { it.price }
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -90,9 +90,6 @@ class ParkingHistoryService(
     fun getDailyRevenue(date: LocalDate): Double {
         val startOfDay = date.atStartOfDay()
         val endOfDay = date.atTime(LocalTime.MAX)
-
-        val parkings = parkingHistoryRepository.findAllByEndTimeBetween(startOfDay, endOfDay)
-
-        return parkings.sumOf { it.price }
+        return parkingHistoryRepository.sumPriceByEndTimeBetween(startOfDay, endOfDay)
     }
 }


### PR DESCRIPTION
## 📝 Description
Added a new endpoint in `ParkingHistoryController` to calculate the total parking revenue for a specific day. It sums up the `price` field of all parking history entries that were completed (`endTime`) within the requested date (from `00:00:00` to `23:59:59`).

### Example Usage

`GET` `http://localhost:8080/api/parking-history/daily-revenue?date=2026-04-23`
`Authorization: Bearer <Token>`

### Example Response

`100.5`

### Additional info

* Returns `0.0` if there are no completed parking sessions on the given date.
* Safely covers the entire day using `date.atStartOfDay()` and `date.atTime(LocalTime.MAX)`.


## 🔗 Related Issue
Fixes #61 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.
