### PR TITLE
Parking spaces current occupancy stats endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceController.kt
@@ -64,4 +64,9 @@ class ParkingSpaceController(
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteParkingSpace(@PathVariable id: String) =
         parkingSpaceService.deleteParkingSpace(id)
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'CLIENT')")
+    @GetMapping("/occupancy")
+    fun getParkingStats(): ParkingSpaceStatsDTO =
+        parkingSpaceService.getDetailedStats()
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceDTO.kt
@@ -17,3 +17,10 @@ data class ParkingSpaceDTO (
 
     val level: Int = 0,
 )
+
+data class ParkingSpaceStatsDTO(
+    val free: Long,
+    val occupied: Long,
+    val reserved: Long,
+    val total: Long
+)

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceRepository.kt
@@ -10,4 +10,5 @@ interface ParkingSpaceRepository : JpaRepository<ParkingSpaceEntity, String> {
     fun findAllBySpaceType(spaceType: SpaceType): List<ParkingSpaceEntity>
     fun findAllByStatus(status: ParkingSpaceStatus): List<ParkingSpaceEntity>
     fun findAllByLevelAndSpaceType(level: Int, spaceType: SpaceType): List<ParkingSpaceEntity>
+    fun countByStatus(status: ParkingSpaceStatus): Long
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceRepository.kt
@@ -3,6 +3,7 @@ package com.parkingplus.parkingspaces
 import com.parkingplus.parkingspaces.enums.SpaceType
 import org.springframework.data.jpa.repository.JpaRepository
 import com.parkingplus.parkingspaces.enums.ParkingSpaceStatus
+import org.springframework.data.jpa.repository.Query
 
 
 interface ParkingSpaceRepository : JpaRepository<ParkingSpaceEntity, String> {
@@ -10,5 +11,7 @@ interface ParkingSpaceRepository : JpaRepository<ParkingSpaceEntity, String> {
     fun findAllBySpaceType(spaceType: SpaceType): List<ParkingSpaceEntity>
     fun findAllByStatus(status: ParkingSpaceStatus): List<ParkingSpaceEntity>
     fun findAllByLevelAndSpaceType(level: Int, spaceType: SpaceType): List<ParkingSpaceEntity>
-    fun countByStatus(status: ParkingSpaceStatus): Long
+
+    @Query("SELECT p.status, COUNT(p) FROM ParkingSpaceEntity p GROUP BY p.status")
+    fun countByStatusGrouped(): List<Array<Any>>
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
@@ -75,10 +75,24 @@ class ParkingSpaceService(
 
     @Transactional(readOnly = true)
     fun getDetailedStats(): ParkingSpaceStatsDTO {
-        val free = parkingSpaceRepository.countByStatus(ParkingSpaceStatus.FREE)
-        val occupied = parkingSpaceRepository.countByStatus(ParkingSpaceStatus.OCCUPIED)
-        val reserved = parkingSpaceRepository.countByStatus(ParkingSpaceStatus.RESERVED)
-        val total = parkingSpaceRepository.count()
+        val groupedCounts = parkingSpaceRepository.countByStatusGrouped()
+
+        var free = 0L
+        var occupied = 0L
+        var reserved = 0L
+
+        groupedCounts.forEach { row ->
+            val status = row[0] as ParkingSpaceStatus
+            val count = (row[1] as Number).toLong()
+
+            when (status) {
+                ParkingSpaceStatus.FREE -> free = count
+                ParkingSpaceStatus.OCCUPIED -> occupied = count
+                ParkingSpaceStatus.RESERVED -> reserved = count
+            }
+        }
+
+        val total = free + occupied + reserved
 
         return ParkingSpaceStatsDTO(free, occupied, reserved, total)
     }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
@@ -72,4 +72,14 @@ class ParkingSpaceService(
         }
         parkingSpaceRepository.deleteById(id)
     }
+
+    @Transactional(readOnly = true)
+    fun getDetailedStats(): ParkingSpaceStatsDTO {
+        val free = parkingSpaceRepository.countByStatus(ParkingSpaceStatus.FREE)
+        val occupied = parkingSpaceRepository.countByStatus(ParkingSpaceStatus.OCCUPIED)
+        val reserved = parkingSpaceRepository.countByStatus(ParkingSpaceStatus.RESERVED)
+        val total = parkingSpaceRepository.count()
+
+        return ParkingSpaceStatsDTO(free, occupied, reserved, total)
+    }
 }


### PR DESCRIPTION
## 📝 Description
Introduced a new endpoint `/api/parking-spaces/occupancy` that provides real-time information about parking availability. It returns counts for Free, Occupied, and Reserved spaces, along with the total capacity. It's available for CLIENT and ADMIN roles.

### Example usage
`GET` `http://localhost:8080/api/parking-spaces/occupancy`
`Authorization: Bearer <Token>`

### Example response
```json
{
    "free": 45,
    "occupied": 10,
    "reserved": 5,
    "total": 60
}
```

## 🔗 Related Issue
Fixes #60 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.
