### PR TITLE
Feature/Add revenue data endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
@@ -97,4 +97,13 @@ class ParkingHistoryController(
     ): ResponseEntity<EntriesResponseDTO> {
         return ResponseEntity.ok(parkingHistoryService.getEntriesStatistics(date, period))
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/revenue-stats")
+    fun getRevenueStats(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        @RequestParam period: AggregationPeriod
+    ): ResponseEntity<RevenueStatsResponseDTO> {
+        return ResponseEntity.ok(parkingHistoryService.getRevenueStatistics(date, period))
+    }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -25,6 +25,7 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("start") start: LocalDateTime,
         @Param("end") end: LocalDateTime
     ): List<LocalDateTime>
+
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
 
     interface RevenueProjection {
@@ -32,7 +33,7 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         val price: Double
     }
 
-    @Query("SELECT p.endTime as endTime, p.price as price FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end AND p.price IS NOT NULL")
+    @Query("SELECT p.endTime as endTime, p.price as price FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end")
     fun findRevenueBetween(
         @Param("start") start: LocalDateTime,
         @Param("end") end: LocalDateTime

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -26,4 +26,16 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("end") end: LocalDateTime
     ): List<LocalDateTime>
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
+
+    interface RevenueProjection {
+        val endTime: LocalDateTime
+        val price: Double
+    }
+
+    @Query("SELECT p.endTime as endTime, p.price as price FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end AND p.price IS NOT NULL")
+    fun findRevenueBetween(
+        @Param("start") start: LocalDateTime,
+        @Param("end") end: LocalDateTime
+    ): List<RevenueProjection>
 }
+

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -235,8 +235,7 @@ class ParkingHistoryService(
         }
 
         val currentData = parkingHistoryRepository.findRevenueBetween(currentStart, currentEnd)
-        val previousTotal = parkingHistoryRepository.sumPriceByEndTimeBetween(previousStart, previousEnd) ?: 0.0
-
+        val previousTotal = parkingHistoryRepository.sumPriceByEndTimeBetween(previousStart, previousEnd)
         var currentTotal = 0.0
 
         val pointsMap = when (period) {

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -8,7 +8,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.DayOfWeek
-import java.time.format.DateTimeFormatter
+import kotlin.math.round
 
 @Service
 class ParkingHistoryService(
@@ -204,5 +204,94 @@ class ParkingHistoryService(
                 )
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun getRevenueStatistics(date: LocalDate, period: AggregationPeriod): RevenueStatsResponseDTO {
+        val currentStart: LocalDateTime
+        val currentEnd: LocalDateTime
+        val previousStart: LocalDateTime
+        val previousEnd: LocalDateTime
+
+        when (period) {
+            AggregationPeriod.DAILY -> {
+                currentStart = date.atStartOfDay()
+                currentEnd = date.atTime(LocalTime.MAX)
+                previousStart = currentStart.minusDays(1)
+                previousEnd = currentEnd.minusDays(1)
+            }
+            AggregationPeriod.WEEKLY -> {
+                currentStart = date.with(DayOfWeek.MONDAY).atStartOfDay()
+                currentEnd = date.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX)
+                previousStart = currentStart.minusWeeks(1)
+                previousEnd = currentEnd.minusWeeks(1)
+            }
+            AggregationPeriod.YEARLY -> {
+                currentStart = date.withDayOfYear(1).atStartOfDay()
+                currentEnd = date.withDayOfYear(date.lengthOfYear()).atTime(LocalTime.MAX)
+                previousStart = currentStart.minusYears(1)
+                previousEnd = currentEnd.minusYears(1)
+            }
+        }
+
+        val currentData = parkingHistoryRepository.findRevenueBetween(currentStart, currentEnd)
+        val previousTotal = parkingHistoryRepository.sumPriceByEndTimeBetween(previousStart, previousEnd) ?: 0.0
+
+        var currentTotal = 0.0
+
+        val pointsMap = when (period) {
+            AggregationPeriod.DAILY -> {
+                val map = linkedMapOf<String, Double>()
+                for (i in 0..22 step 2) map["$i:00"] = 0.0
+                currentData.forEach {
+                    val hour = it.endTime.hour
+                    val bucket = hour - (hour % 2)
+                    map["$bucket:00"] = (map["$bucket:00"] ?: 0.0) + it.price
+                    currentTotal += it.price
+                }
+                map
+            }
+            AggregationPeriod.WEEKLY -> {
+                val map = linkedMapOf("MON" to 0.0, "TUE" to 0.0, "WED" to 0.0, "THU" to 0.0, "FRI" to 0.0, "SAT" to 0.0, "SUN" to 0.0)
+                currentData.forEach {
+                    val day = it.endTime.dayOfWeek.name.substring(0, 3)
+                    map[day] = (map[day] ?: 0.0) + it.price
+                    currentTotal += it.price
+                }
+                map
+            }
+            AggregationPeriod.YEARLY -> {
+                val map = linkedMapOf("JAN" to 0.0, "FEB" to 0.0, "MAR" to 0.0, "APR" to 0.0, "MAY" to 0.0, "JUN" to 0.0, "JUL" to 0.0, "AUG" to 0.0, "SEP" to 0.0, "OCT" to 0.0, "NOV" to 0.0, "DEC" to 0.0)
+                currentData.forEach {
+                    val month = it.endTime.month.name.substring(0, 3)
+                    map[month] = (map[month] ?: 0.0) + it.price
+                    currentTotal += it.price
+                }
+                map
+            }
+        }
+
+        val percentChange = if (previousTotal > 0.0) {
+            ((currentTotal - previousTotal) / previousTotal) * 100.0
+        } else if (currentTotal > 0.0) {
+            100.0
+        } else {
+            0.0
+        }
+
+        val roundedPercentChange = round(percentChange * 10) / 10.0
+        val roundedTotal = round(currentTotal * 100) / 100.0
+
+        return RevenueStatsResponseDTO(
+            period = period,
+            from = currentStart.toLocalDate(),
+            to = currentEnd.toLocalDate(),
+            total = roundedTotal,
+            previousPeriodChangePercent = roundedPercentChange,
+            currency = "PLN", // TODO: Hardcoded for now, consider making it dynamic in the future
+            points = pointsMap.map {
+                RevenuePointDTO(it.key, round(it.value * 100) / 100.0)
+            }
+        )
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/RevenueStatsDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/RevenueStatsDTO.kt
@@ -1,0 +1,18 @@
+package com.parkingplus.parkinghistory
+
+import java.time.LocalDate
+
+data class RevenuePointDTO(
+    val label: String,
+    val value: Double
+)
+
+data class RevenueStatsResponseDTO(
+    val period: AggregationPeriod,
+    val from: LocalDate,
+    val to: LocalDate,
+    val total: Double,
+    val previousPeriodChangePercent: Double,
+    val currency: String = "PLN",
+    val points: List<RevenuePointDTO>
+)


### PR DESCRIPTION
## 📝 Description
Implemented a new administrative endpoint `GET /api/parking-history/revenue-stats` to supply the frontend dashboard with financial data. Unlike entry statistics which rely on `startTime`, revenue is strictly calculated using the `endTime (when the transaction concludes and price is finalized).

`GET http://localhost:8080/api/parking-history/revenue-stats?date=2026-04-30&period=DAILY`

Example return:
```json
{
  "period": "DAILY",
  "from": "2026-04-30",
  "to": "2026-04-30",
  "total": 100.0,
  "previousPeriodChangePercent": 100.0,
  "currency": "PLN",
  "points": [
    { "label": "0:00", "value": 0.0 },
    { "label": "2:00", "value": 0.0 },
    { "label": "4:00", "value": 0.0 },
    { "label": "6:00", "value": 0.0 },
    { "label": "8:00", "value": 20.0 },
    { "label": "10:00", "value": 0.0 },
    { "label": "12:00", "value": 0.0 },
    { "label": "14:00", "value": 30.0 },
    { "label": "16:00", "value": 0.0 },
    { "label": "18:00", "value": 50.0 },
    { "label": "20:00", "value": 0.0 },
    { "label": "22:00", "value": 0.0 }
  ]
}
```

## 🔗 Related Issue
Fixes #73 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.
