### PR TITLE
Add average parking stay duration statistics endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/AverageStayStatsDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/AverageStayStatsDTO.kt
@@ -1,0 +1,17 @@
+package com.parkingplus.parkinghistory
+
+import com.parkingplus.parkingspaces.enums.SpaceType
+import java.time.LocalDate
+
+data class AverageStayCategoryItemDTO(
+    val spaceType: SpaceType,
+    val averageMinutes: Long
+)
+
+data class AverageStayResponseDTO(
+    val period: AggregationPeriod,
+    val from: LocalDate,
+    val to: LocalDate,
+    val overallAverageMinutes: Long,
+    val categories: List<AverageStayCategoryItemDTO>
+)

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
@@ -97,4 +97,13 @@ class ParkingHistoryController(
     ): ResponseEntity<EntriesResponseDTO> {
         return ResponseEntity.ok(parkingHistoryService.getEntriesStatistics(date, period))
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/average-stay")
+    fun getAverageStayStats(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        @RequestParam period: AggregationPeriod
+    ): ResponseEntity<AverageStayResponseDTO> {
+        return ResponseEntity.ok(parkingHistoryService.getAverageStayStatistics(date, period))
+    }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -1,5 +1,6 @@
 package com.parkingplus.parkinghistory
 
+import com.parkingplus.parkingspaces.enums.SpaceType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -26,4 +27,18 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("end") end: LocalDateTime
     ): List<LocalDateTime>
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
+
+
+
+    @Query("SELECT p.startTime as startTime, p.endTime as endTime, p.parkingSpace.spaceType as spaceType FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end AND p.endTime IS NOT NULL")
+    fun findCompletedStaysBetween(
+        @Param("start") start: LocalDateTime,
+        @Param("end") end: LocalDateTime
+    ): List<AverageStayProjection>
+}
+
+interface AverageStayProjection {
+    val startTime: LocalDateTime
+    val endTime: LocalDateTime
+    val spaceType: SpaceType
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -26,11 +26,11 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("start") start: LocalDateTime,
         @Param("end") end: LocalDateTime
     ): List<LocalDateTime>
+
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
 
 
-
-    @Query("SELECT p.startTime as startTime, p.endTime as endTime, p.parkingSpace.spaceType as spaceType FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end AND p.endTime IS NOT NULL")
+    @Query("SELECT p.startTime as startTime, p.endTime as endTime, p.parkingSpace.spaceType as spaceType FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end")
     fun findCompletedStaysBetween(
         @Param("start") start: LocalDateTime,
         @Param("end") end: LocalDateTime

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -1,6 +1,7 @@
 package com.parkingplus.parkinghistory
 
 import com.parkingplus.parkingspaces.ParkingSpaceRepository
+import com.parkingplus.parkingspaces.enums.SpaceType
 import com.parkingplus.vehicles.VehicleRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -8,6 +9,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.DayOfWeek
+import java.time.Duration
 import java.time.format.DateTimeFormatter
 
 @Service
@@ -204,5 +206,52 @@ class ParkingHistoryService(
                 )
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun getAverageStayStatistics(date: LocalDate, period: AggregationPeriod): AverageStayResponseDTO {
+        val currentStart: LocalDateTime
+        val currentEnd: LocalDateTime
+
+        when (period) {
+            AggregationPeriod.DAILY -> {
+                currentStart = date.atStartOfDay()
+                currentEnd = date.atTime(LocalTime.MAX)
+            }
+            AggregationPeriod.WEEKLY -> {
+                currentStart = date.with(DayOfWeek.MONDAY).atStartOfDay()
+                currentEnd = date.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX)
+            }
+            AggregationPeriod.YEARLY -> {
+                currentStart = date.withDayOfYear(1).atStartOfDay()
+                currentEnd = date.withDayOfYear(date.lengthOfYear()).atTime(LocalTime.MAX)
+            }
+        }
+
+        val stays = parkingHistoryRepository.findCompletedStaysBetween(currentStart, currentEnd)
+
+        var totalMinutesOverall = 0L
+        val typeDurations = mutableMapOf<SpaceType, MutableList<Long>>()
+
+        stays.forEach { stay ->
+            val minutes = Duration.between(stay.startTime, stay.endTime).toMinutes()
+            totalMinutesOverall += minutes
+            typeDurations.computeIfAbsent(stay.spaceType) { mutableListOf() }.add(minutes)
+        }
+
+        val overallAverage = if (stays.isNotEmpty()) totalMinutesOverall / stays.size else 0L
+
+        val categories = typeDurations.map { (spaceType, durations) ->
+            val avg = if (durations.isNotEmpty()) durations.sum() / durations.size else 0L
+            AverageStayCategoryItemDTO(spaceType, avg)
+        }
+
+        return AverageStayResponseDTO(
+            period = period,
+            from = currentStart.toLocalDate(),
+            to = currentEnd.toLocalDate(),
+            overallAverageMinutes = overallAverage,
+            categories = categories
+        )
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -218,10 +218,12 @@ class ParkingHistoryService(
                 currentStart = date.atStartOfDay()
                 currentEnd = date.atTime(LocalTime.MAX)
             }
+
             AggregationPeriod.WEEKLY -> {
                 currentStart = date.with(DayOfWeek.MONDAY).atStartOfDay()
                 currentEnd = date.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX)
             }
+
             AggregationPeriod.YEARLY -> {
                 currentStart = date.withDayOfYear(1).atStartOfDay()
                 currentEnd = date.withDayOfYear(date.lengthOfYear()).atTime(LocalTime.MAX)
@@ -231,20 +233,33 @@ class ParkingHistoryService(
         val stays = parkingHistoryRepository.findCompletedStaysBetween(currentStart, currentEnd)
 
         var totalMinutesOverall = 0L
-        val typeDurations = mutableMapOf<SpaceType, MutableList<Long>>()
+        var validStayCount = 0L
+
+        val typeTotalMinutes = mutableMapOf<SpaceType, Long>()
+        val typeCounts = mutableMapOf<SpaceType, Int>()
 
         stays.forEach { stay ->
-            val minutes = Duration.between(stay.startTime, stay.endTime).toMinutes()
-            totalMinutesOverall += minutes
-            typeDurations.computeIfAbsent(stay.spaceType) { mutableListOf() }.add(minutes)
+
+            if (stay.endTime.isAfter(stay.startTime)) {
+                val minutes = Duration.between(stay.startTime, stay.endTime).toMinutes()
+
+                totalMinutesOverall += minutes
+                validStayCount++
+
+                typeTotalMinutes[stay.spaceType] = (typeTotalMinutes[stay.spaceType] ?: 0L) + minutes
+                typeCounts[stay.spaceType] = (typeCounts[stay.spaceType] ?: 0) + 1
+            }
         }
 
-        val overallAverage = if (stays.isNotEmpty()) totalMinutesOverall / stays.size else 0L
+        val overallAverage = if (validStayCount > 0) totalMinutesOverall / validStayCount else 0L
 
-        val categories = typeDurations.map { (spaceType, durations) ->
-            val avg = if (durations.isNotEmpty()) durations.sum() / durations.size else 0L
-            AverageStayCategoryItemDTO(spaceType, avg)
-        }
+        val categories = typeTotalMinutes.entries
+            .sortedBy { it.key.name }
+            .map { (spaceType, totalMinutes) ->
+                val count = typeCounts[spaceType] ?: 0
+                val avg = if (count > 0) totalMinutes / count else 0L
+                AverageStayCategoryItemDTO(spaceType, avg)
+            }
 
         return AverageStayResponseDTO(
             period = period,


### PR DESCRIPTION
## 📝 Description
Implemented a new administrative endpoint `GET /api/parking-history/average-stay` designed to feed the dashboard chart displaying the average duration of completed parking sessions.

Example Request (DAILY view):
`GET /api/parking-history/average-stay?date=2026-03-08&period=DAILY`

Example Response (200 OK):
```json
{
  "period": "DAILY",
  "from": "2026-03-08",
  "to": "2026-03-08",
  "overallAverageMinutes": 134,
  "categories": [
    {
      "spaceType": "REGULAR_ABLEBODIED",
      "averageMinutes": 135
    },
    {
      "spaceType": "REGULAR_HANDICAPED",
      "averageMinutes": 65
    },
    {
      "spaceType": "EV_ABLEBODIED",
      "averageMinutes": 270
    }
  ]
}
```

## 🔗 Related Issue
Fixes #76 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.