### PR TITLE
Add daily parking space usage ranking endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/PArkingRankingDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/PArkingRankingDTO.kt
@@ -1,0 +1,18 @@
+package com.parkingplus.parkinghistory
+
+enum class ParkingFloor(val level: Int) {
+    A(1),
+    B(2),
+    C(3)
+}
+
+data class ParkingSpaceRankingPointDTO(
+    val spaceId: String,
+    val value: Long
+)
+
+data class ParkingSpaceRankingResponseDTO(
+    val floor: ParkingFloor,
+    val total: Long,
+    val points: List<ParkingSpaceRankingPointDTO>
+)

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
@@ -97,4 +97,13 @@ class ParkingHistoryController(
     ): ResponseEntity<EntriesResponseDTO> {
         return ResponseEntity.ok(parkingHistoryService.getEntriesStatistics(date, period))
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/ranking")
+    fun getSpaceRanking(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        @RequestParam floor: ParkingFloor
+    ): ResponseEntity<ParkingSpaceRankingResponseDTO> {
+        return ResponseEntity.ok(parkingHistoryService.getSpaceRanking(date, floor))
+    }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -26,4 +26,23 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("end") end: LocalDateTime
     ): List<LocalDateTime>
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
+
+    @Query(
+        "SELECT p.parkingSpace.id as spaceId, COUNT(p.id) as usageCount " +
+                "FROM ParkingHistoryEntity p " +
+                "WHERE p.parkingSpace.level = :level " +
+                "AND p.startTime BETWEEN :start AND :end " +
+                "GROUP BY p.parkingSpace.id " +
+                "ORDER BY usageCount DESC"
+    )
+    fun findSpaceRankingForLevelAndDate(
+        @Param("level") level: Int,
+        @Param("start") start: LocalDateTime,
+        @Param("end") end: LocalDateTime
+    ): List<SpaceRankingProjection>
+}
+
+interface SpaceRankingProjection {
+    val spaceId: String
+    val usageCount: Long
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -205,4 +205,31 @@ class ParkingHistoryService(
             }
         }
     }
+
+    @Transactional(readOnly = true)
+    fun getSpaceRanking(date: LocalDate, floor: ParkingFloor): ParkingSpaceRankingResponseDTO {
+        val startOfDay = date.atStartOfDay()
+        val endOfDay = date.atTime(LocalTime.MAX)
+
+        val rankingData = parkingHistoryRepository.findSpaceRankingForLevelAndDate(
+            level = floor.level,
+            start = startOfDay,
+            end = endOfDay
+        )
+
+        val totalEntries = rankingData.sumOf { it.usageCount }
+
+        val points = rankingData.map {
+            ParkingSpaceRankingPointDTO(
+                spaceId = it.spaceId,
+                value = it.usageCount
+            )
+        }
+
+        return ParkingSpaceRankingResponseDTO(
+            floor = floor,
+            total = totalEntries,
+            points = points
+        )
+    }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingRankingDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingRankingDTO.kt
@@ -2,8 +2,7 @@ package com.parkingplus.parkinghistory
 
 enum class ParkingFloor(val level: Int) {
     A(1),
-    B(2),
-    C(3)
+    B(2)
 }
 
 data class ParkingSpaceRankingPointDTO(


### PR DESCRIPTION
## 📝 Description
Implemented the `GET /api/parking-history/ranking` endpoint to generate a daily heatmap/ranking of parking spaces based on their usage frequency for a specific floor.

Example Request:
`GET /api/parking-history/ranking?date=2026-08-03&floor=A`

Example Response (200 OK):
```json
{
  "floor": "A",
  "total": 6,
  "points": [
    {
      "spaceId": "A1",
      "value": 3
    },
    {
      "spaceId": "A2",
      "value": 2
    },
    {
      "spaceId": "A3",
      "value": 1
    }
  ]
}
```

## 🔗 Related Issue
Fixes #77 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.
