### PR TITLE
Add daily parking space timeline endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -32,7 +32,7 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         "SELECT p FROM ParkingHistoryEntity p " +
                 "WHERE p.parkingSpace.id = :spaceId " +
                 "AND p.startTime <= :endOfDay " +
-                "AND (p.endTime >= :startOfDay OR p.endTime IS NULL)"
+                "AND (p.endTime > :startOfDay OR p.endTime IS NULL)"
     )
     fun findTimelineForSpaceAndDate(
         @Param("spaceId") spaceId: String,

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -25,5 +25,18 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("start") start: LocalDateTime,
         @Param("end") end: LocalDateTime
     ): List<LocalDateTime>
+
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
+
+    @Query(
+        "SELECT p FROM ParkingHistoryEntity p " +
+                "WHERE p.parkingSpace.id = :spaceId " +
+                "AND p.startTime <= :endOfDay " +
+                "AND (p.endTime >= :startOfDay OR p.endTime IS NULL)"
+    )
+    fun findTimelineForSpaceAndDate(
+        @Param("spaceId") spaceId: String,
+        @Param("startOfDay") startOfDay: LocalDateTime,
+        @Param("endOfDay") endOfDay: LocalDateTime
+    ): List<ParkingHistoryEntity>
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceController.kt
@@ -6,6 +6,9 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+import org.springframework.http.ResponseEntity
 
 @RestController
 @RequestMapping("/api/parking-spaces")
@@ -74,4 +77,13 @@ class ParkingSpaceController(
     @GetMapping("/{id}/details")
     fun getParkingSpaceDetails(@PathVariable id: String): ParkingSpotDetailsDTO =
         parkingSpaceService.getSpaceDetails(id)
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{id}/timeline")
+    fun getSpaceTimeline(
+        @PathVariable id: String,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
+    ): ResponseEntity<ParkingSpaceTimelineResponseDTO> {
+        return ResponseEntity.ok(parkingSpaceService.getSpaceTimeline(id, date))
+    }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
@@ -5,7 +5,10 @@ import com.parkingplus.parkingspaces.enums.ParkingSpaceStatus
 import com.parkingplus.parkingspaces.enums.SpaceType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import java.util.NoSuchElementException
 
 @Service
@@ -136,6 +139,43 @@ class ParkingSpaceService(
             status = actualStatus,
             level = space.level,
             occupant = occupantDto
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getSpaceTimeline(spaceId: String, date: LocalDate): ParkingSpaceTimelineResponseDTO {
+        val startOfDay = date.atStartOfDay()
+        val endOfDay = date.atTime(LocalTime.MAX)
+
+        val histories = parkingHistoryRepository.findTimelineForSpaceAndDate(spaceId, startOfDay, endOfDay)
+        val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+        val items = histories.map { history ->
+            val fromStr = if (history.startTime.isBefore(startOfDay)) {
+                "00:00"
+            } else {
+                history.startTime.format(timeFormatter)
+            }
+
+            val toStr = if (history.endTime == null || history.endTime!!.isAfter(endOfDay)) {
+                "23:59"
+            } else {
+                history.endTime!!.format(timeFormatter)
+            }
+
+            ParkingSpaceTimelineItemDTO(
+                status = ParkingSpaceTimelineStatus.OCCUPIED,
+                from = fromStr,
+                to = toStr
+            )
+        }
+
+        // TODO: Fetch reservation -> map to RESERVED and add to `items`
+
+        return ParkingSpaceTimelineResponseDTO(
+            spaceId = spaceId,
+            date = date,
+            items = items.sortedBy { it.from }
         )
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceService.kt
@@ -144,6 +144,10 @@ class ParkingSpaceService(
 
     @Transactional(readOnly = true)
     fun getSpaceTimeline(spaceId: String, date: LocalDate): ParkingSpaceTimelineResponseDTO {
+        if (!parkingSpaceRepository.existsById(spaceId)) {
+            throw NoSuchElementException("Parking space with id $spaceId does not exist.")
+        }
+
         val startOfDay = date.atStartOfDay()
         val endOfDay = date.atTime(LocalTime.MAX)
 
@@ -164,13 +168,12 @@ class ParkingSpaceService(
             }
 
             ParkingSpaceTimelineItemDTO(
-                status = ParkingSpaceTimelineStatus.OCCUPIED,
+                status = com.parkingplus.parkingspaces.enums.ParkingSpaceTimelineStatus.OCCUPIED,
                 from = fromStr,
                 to = toStr
             )
         }
-
-        // TODO: Fetch reservation -> map to RESERVED and add to `items`
+            .filter { it.from != it.to }
 
         return ParkingSpaceTimelineResponseDTO(
             spaceId = spaceId,

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceTimelineDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceTimelineDTO.kt
@@ -1,0 +1,20 @@
+package com.parkingplus.parkingspaces
+
+import java.time.LocalDate
+
+enum class ParkingSpaceTimelineStatus {
+    OCCUPIED,
+    RESERVED
+}
+
+data class ParkingSpaceTimelineItemDTO(
+    val status: ParkingSpaceTimelineStatus,
+    val from: String,   // "HH:mm"
+    val to: String      // "HH:mm"
+)
+
+data class ParkingSpaceTimelineResponseDTO(
+    val spaceId: String,
+    val date: LocalDate,
+    val items: List<ParkingSpaceTimelineItemDTO>
+)

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceTimelineDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceTimelineDTO.kt
@@ -1,11 +1,8 @@
 package com.parkingplus.parkingspaces
 
+import com.parkingplus.parkingspaces.enums.ParkingSpaceTimelineStatus
 import java.time.LocalDate
 
-enum class ParkingSpaceTimelineStatus {
-    OCCUPIED,
-    RESERVED
-}
 
 data class ParkingSpaceTimelineItemDTO(
     val status: ParkingSpaceTimelineStatus,

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/enums/ParkingSpaceTimelineStatus.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/enums/ParkingSpaceTimelineStatus.kt
@@ -1,0 +1,6 @@
+package com.parkingplus.parkingspaces.enums
+
+enum class ParkingSpaceTimelineStatus {
+    OCCUPIED,
+    RESERVED
+}


### PR DESCRIPTION
## 📝 Description
Implemented a new endpoint `GET /api/parking-spaces/{id}/timeline` to fetch the chronological daily schedule for a specific parking space. This endpoint maps backend history data to render timeline charts on the frontend.

Example Request:
`GET /api/parking-spaces/A17/timeline?date=2026-03-08`

Example Response (200 OK):

```json
{
  "spaceId": "A17",
  "date": "2026-03-08",
  "items": [
    {
      "status": "OCCUPIED",
      "from": "00:00",
      "to": "07:00"
    },
    {
      "status": "OCCUPIED",
      "from": "07:10",
      "to": "09:25"
    },
    {
      "status": "OCCUPIED",
      "from": "19:05",
      "to": "23:59"
    }
  ]
}
```

## 🔗 Related Issue
Fixes #78 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.