### PR TITLE
Simple register endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/auth/AuthController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/auth/AuthController.kt
@@ -2,7 +2,10 @@ package com.parkingplus.auth
 
 import com.parkingplus.security.JwtService
 import com.parkingplus.security.TwoFactorAuthService
+import com.parkingplus.users.UserDTO
 import com.parkingplus.users.UserRepository
+import com.parkingplus.users.UserService
+import com.parkingplus.users.requests.CreateUserRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -15,7 +18,8 @@ class AuthController(
     private val passwordEncoder: PasswordEncoder,
     private val jwtService: JwtService,
     private val tfaService: TwoFactorAuthService,
-    private val passwordResetService: PasswordResetService
+    private val passwordResetService: PasswordResetService,
+    private val userService: UserService
 ) {
 
     companion object {
@@ -32,10 +36,12 @@ class AuthController(
         }
 
         if (user.isMfaEnabled) {
-            return ResponseEntity.ok(LoginResponse(
-                mfaRequired = true,
-                preAuthToken = jwtService.generatePreAuthToken(user)
-            ))
+            return ResponseEntity.ok(
+                LoginResponse(
+                    mfaRequired = true,
+                    preAuthToken = jwtService.generatePreAuthToken(user)
+                )
+            )
         }
 
         val token = jwtService.generateToken(user)
@@ -75,5 +81,11 @@ class AuthController(
         } else {
             ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Nieprawidłowy lub wygasły token.")
         }
+    }
+
+    @PostMapping("/register")
+    fun register(@RequestBody request: CreateUserRequest): ResponseEntity<UserDTO> {
+        val user = userService.registerUser(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(user)
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/auth/AuthController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/auth/AuthController.kt
@@ -6,6 +6,7 @@ import com.parkingplus.users.UserDTO
 import com.parkingplus.users.UserRepository
 import com.parkingplus.users.UserService
 import com.parkingplus.users.requests.CreateUserRequest
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -84,8 +85,15 @@ class AuthController(
     }
 
     @PostMapping("/register")
-    fun register(@RequestBody request: CreateUserRequest): ResponseEntity<UserDTO> {
-        val user = userService.registerUser(request)
+    fun register(@Valid @RequestBody request: RegisterUserRequest): ResponseEntity<UserDTO> {
+        val createUserRequest = CreateUserRequest(
+            name = request.name,
+            surname = request.surname,
+            email = request.email,
+            password = request.password,
+            isOperator = false
+        )
+        val user = userService.createUser(createUserRequest)
         return ResponseEntity.status(HttpStatus.CREATED).body(user)
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/auth/RegisterUserRequest.kt
+++ b/backend/src/main/kotlin/com/parkingplus/auth/RegisterUserRequest.kt
@@ -1,0 +1,19 @@
+package com.parkingplus.auth
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class RegisterUserRequest(
+    @field:NotBlank(message = "Imię nie może być puste")
+    val name: String = "",
+
+    @field:NotBlank(message = "Nazwisko nie może być puste")
+    val surname: String = "",
+
+    @field:Email(message = "To nie jest poprawny adres e-mail")
+    @field:NotBlank(message = "Email jest wymagany")
+    val email: String = "",
+
+    @field:NotBlank(message = "Hasło jest wymagane")
+    val password: String = ""
+)

--- a/backend/src/main/kotlin/com/parkingplus/users/UserService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserService.kt
@@ -9,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 @Service
 class UserService(
@@ -41,7 +43,7 @@ class UserService(
     @Transactional
     fun createUser(request: CreateUserRequest): UserDTO {
         if (userRepository.existsByEmail(request.email)) {
-            throw IllegalArgumentException("Użytkownik z mailem ${request.email} już istnieje.")
+            throw ResponseStatusException(HttpStatus.CONFLICT, "Użytkownik z mailem ${request.email} już istnieje.")
         }
 
         val hashedPassword = passwordEncoder.encode(request.password)
@@ -53,7 +55,7 @@ class UserService(
     @Transactional
     fun createOperator(request: CreateUserRequest): UserDTO {
         if (userRepository.existsByEmail(request.email)) {
-            throw IllegalArgumentException("Użytkownik z mailem ${request.email} już istnieje.")
+            throw ResponseStatusException(HttpStatus.CONFLICT, "Użytkownik z mailem ${request.email} już istnieje.")
         }
 
         val hashedPassword = passwordEncoder.encode(request.password)
@@ -104,17 +106,5 @@ class UserService(
             return true
         }
         return false
-    }
-
-    @Transactional
-    fun registerUser(request: CreateUserRequest): UserDTO {
-        if (userRepository.existsByEmail(request.email)) {
-            throw IllegalArgumentException("Użytkownik z mailem ${request.email} już istnieje.")
-        }
-
-        val hashedPassword = passwordEncoder.encode(request.password)
-        val entity = request.toEntity(hashedPassword)
-
-        return userRepository.save(entity).toDTO()
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/users/UserService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserService.kt
@@ -105,4 +105,16 @@ class UserService(
         }
         return false
     }
+
+    @Transactional
+    fun registerUser(request: CreateUserRequest): UserDTO {
+        if (userRepository.existsByEmail(request.email)) {
+            throw IllegalArgumentException("Użytkownik z mailem ${request.email} już istnieje.")
+        }
+
+        val hashedPassword = passwordEncoder.encode(request.password)
+        val entity = request.toEntity(hashedPassword)
+
+        return userRepository.save(entity).toDTO()
+    }
 }


### PR DESCRIPTION
## 📝 Description
This PR introduces a new endpoint for user registration, allowing new users to create an account in the system.

## Changes made
* **`UserService.kt`**: Added `registerUser` method that validates email uniqueness, hashes the password using `PasswordEncoder`, and saves the new user to the database.
* **`AuthController.kt`**: Added the `POST /api/auth/register` endpoint which consumes `CreateUserRequest` and returns the newly created user as `UserDTO`.

## How to test

### Example request
`POST http://localhost:8080/api/auth/register`

Body:
```json
{
   "name": "John",
   "surname": "Doe",
   "email": "john.doe@example.com",
   "password": "SecurePassword123!"
}
```
### Example Response (201 Created)
```json
{
    "id": 123,
    "name": "John",
    "surname": "Doe",
    "email": "john.doe@example.com",
    "isOperator": false,
    "isMfaEnabled": false
}
 ```

## 🔗 Related Issue
Fixes #80 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.