### PR TITLE
Add `\me` endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/users/UserController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserController.kt
@@ -36,7 +36,7 @@ class UserController(private val userService: UserService) {
     }
 
     @PreAuthorize("hasAnyRole('ADMIN', 'CLIENT')")
-    @GetMapping("/{id}")
+    @GetMapping("/{id:\\d+}")
     fun getById(@PathVariable id: Long, authentication: Authentication): ResponseEntity<UserDTO> {
         val authUserId = authentication.details as? Long
         if (authentication.authorities.none { it.authority == "ROLE_ADMIN" } && authUserId != id) {
@@ -85,5 +85,14 @@ class UserController(private val userService: UserService) {
         } else {
             ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Nieprawidłowy kod weryfikacyjny")
         }
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'CLIENT')")
+    @GetMapping("/me")
+    fun getCurrentUser(authentication: Authentication): ResponseEntity<UserDTO> {
+        val authUserId = authentication.details as? Long
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
+        return ResponseEntity.ok(userService.getUserById(authUserId))
     }
 }


### PR DESCRIPTION
## 📝 Description
This PR introduces the `/api/users/me` endpoint, allowing authenticated users (both clients and admins) to fetch their own profile details without needing to pass their user ID in the URL.

It also fixes a routing conflict where the string `"me"` was being mistakenly parsed as a numeric ID.

## Changes made
* **`UserController.kt`**:
    * Added the `getCurrentUser` method mapped to `@GetMapping("/me")`. It extracts the `userId` directly from the JWT `Authentication` details.
    * Updated the existing `getById` endpoint mapping from `@GetMapping("/{id}")` to `@GetMapping("/{id:\\d+}")`. This regex
      ensures that only numeric IDs are processed by `getById`, preventing `TypeMismatchException` when calling `/me`.

## How to test
Make sure you are logged in and have a valid JWT token. Then, use the following `curl` command (replace `<YOUR_TOKEN>` with your actual token):

### Example Request
`GET http://localhost:8080/api/users/me`
"Authorization: Bearer <YOUR_TOKEN>"

 ### Example Response (200 OK)
```json
{
    "id": 123,
    "name": "John",
    "surname": "Doe",
    "email": "john.doe@example.com",
    "isOperator": false,
    "isMfaEnabled": false
}
```


## 🔗 Related Issue
Fixes #102 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.