### PR TITLE
add events endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingEventDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingEventDTO.kt
@@ -1,0 +1,12 @@
+package com.parkingplus.parkinghistory
+
+data class ParkingEventDTO(
+    val id: Long,
+    val plateNumber: String,
+    val eventType: String,
+    val eventDate: String,
+    val ownerName: String,
+    val ownerSurname: String,
+    val ownerEmail: String,
+    val carPhotoPath: String?
+)

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingEventDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingEventDTO.kt
@@ -1,10 +1,19 @@
 package com.parkingplus.parkinghistory
 
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+
+enum class ParkingEventType {
+    ENTRY,
+    EXIT
+}
+
 data class ParkingEventDTO(
     val id: Long,
     val plateNumber: String,
-    val eventType: String,
-    val eventDate: String,
+    val eventType: ParkingEventType,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    val eventDate: LocalDateTime,
     val ownerName: String,
     val ownerSurname: String,
     val ownerEmail: String,

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryController.kt
@@ -124,4 +124,10 @@ class ParkingHistoryController(
     ): ResponseEntity<ParkingSpaceRankingResponseDTO> {
         return ResponseEntity.ok(parkingHistoryService.getSpaceRanking(date, floor))
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/events")
+    fun getParkingEvents(): ResponseEntity<List<ParkingEventDTO>> {
+        return ResponseEntity.ok(parkingHistoryService.getParkingEvents())
+    }
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -83,4 +83,7 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
         @Param("startOfDay") startOfDay: LocalDateTime,
         @Param("endOfDay") endOfDay: LocalDateTime
     ): List<ParkingHistoryEntity>
+
+    @Query("SELECT p FROM ParkingHistoryEntity p JOIN FETCH p.vehicle v JOIN FETCH v.owner")
+    fun findAllWithVehicleAndOwner(): List<ParkingHistoryEntity>
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -223,12 +223,14 @@ class ParkingHistoryService(
                 previousStart = currentStart.minusDays(1)
                 previousEnd = currentEnd.minusDays(1)
             }
+
             AggregationPeriod.WEEKLY -> {
                 currentStart = date.with(DayOfWeek.MONDAY).atStartOfDay()
                 currentEnd = date.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX)
                 previousStart = currentStart.minusWeeks(1)
                 previousEnd = currentEnd.minusWeeks(1)
             }
+
             AggregationPeriod.YEARLY -> {
                 currentStart = date.withDayOfYear(1).atStartOfDay()
                 currentEnd = date.withDayOfYear(date.lengthOfYear()).atTime(LocalTime.MAX)
@@ -253,8 +255,17 @@ class ParkingHistoryService(
                 }
                 map
             }
+
             AggregationPeriod.WEEKLY -> {
-                val map = linkedMapOf("MON" to 0.0, "TUE" to 0.0, "WED" to 0.0, "THU" to 0.0, "FRI" to 0.0, "SAT" to 0.0, "SUN" to 0.0)
+                val map = linkedMapOf(
+                    "MON" to 0.0,
+                    "TUE" to 0.0,
+                    "WED" to 0.0,
+                    "THU" to 0.0,
+                    "FRI" to 0.0,
+                    "SAT" to 0.0,
+                    "SUN" to 0.0
+                )
                 currentData.forEach {
                     val day = it.endTime.dayOfWeek.name.substring(0, 3)
                     map[day] = (map[day] ?: 0.0) + it.price
@@ -262,8 +273,22 @@ class ParkingHistoryService(
                 }
                 map
             }
+
             AggregationPeriod.YEARLY -> {
-                val map = linkedMapOf("JAN" to 0.0, "FEB" to 0.0, "MAR" to 0.0, "APR" to 0.0, "MAY" to 0.0, "JUN" to 0.0, "JUL" to 0.0, "AUG" to 0.0, "SEP" to 0.0, "OCT" to 0.0, "NOV" to 0.0, "DEC" to 0.0)
+                val map = linkedMapOf(
+                    "JAN" to 0.0,
+                    "FEB" to 0.0,
+                    "MAR" to 0.0,
+                    "APR" to 0.0,
+                    "MAY" to 0.0,
+                    "JUN" to 0.0,
+                    "JUL" to 0.0,
+                    "AUG" to 0.0,
+                    "SEP" to 0.0,
+                    "OCT" to 0.0,
+                    "NOV" to 0.0,
+                    "DEC" to 0.0
+                )
                 currentData.forEach {
                     val month = it.endTime.month.name.substring(0, 3)
                     map[month] = (map[month] ?: 0.0) + it.price
@@ -307,10 +332,12 @@ class ParkingHistoryService(
                 currentStart = date.atStartOfDay()
                 currentEnd = date.atTime(LocalTime.MAX)
             }
+
             AggregationPeriod.WEEKLY -> {
                 currentStart = date.with(DayOfWeek.MONDAY).atStartOfDay()
                 currentEnd = date.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX)
             }
+
             AggregationPeriod.YEARLY -> {
                 currentStart = date.withDayOfYear(1).atStartOfDay()
                 currentEnd = date.withDayOfYear(date.lengthOfYear()).atTime(LocalTime.MAX)
@@ -382,4 +409,47 @@ class ParkingHistoryService(
             points = points
         )
     }
+
+    @Transactional(readOnly = true)
+    fun getParkingEvents(): List<ParkingEventDTO> {
+        val history = parkingHistoryRepository.findAll()
+        val events = mutableListOf<ParkingEventDTO>()
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
+        for (entry in history) {
+            val owner = entry.vehicle.owner
+            val entryId = entry.id ?: continue
+
+            events.add(
+                ParkingEventDTO(
+                    id = entryId * 10,
+                    plateNumber = entry.vehicle.licensePlate,
+                    eventType = "ENTRY",
+                    eventDate = entry.startTime.format(formatter),
+                    ownerName = owner.name,
+                    ownerSurname = owner.surname,
+                    ownerEmail = owner.email,
+                    carPhotoPath = entry.photoPath
+                )
+            )
+
+            if (entry.endTime != null) {
+                events.add(
+                    ParkingEventDTO(
+                        id = entryId * 10 + 1,
+                        plateNumber = entry.vehicle.licensePlate,
+                        eventType = "EXIT",
+                        eventDate = entry.endTime!!.format(formatter),
+                        ownerName = owner.name,
+                        ownerSurname = owner.surname,
+                        ownerEmail = owner.email,
+                        carPhotoPath = entry.photoPath
+                    )
+                )
+            }
+        }
+
+        return events.sortedByDescending { it.eventDate }
+    }
+
 }

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryService.kt
@@ -412,9 +412,8 @@ class ParkingHistoryService(
 
     @Transactional(readOnly = true)
     fun getParkingEvents(): List<ParkingEventDTO> {
-        val history = parkingHistoryRepository.findAll()
+        val history = parkingHistoryRepository.findAllWithVehicleAndOwner()
         val events = mutableListOf<ParkingEventDTO>()
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
 
         for (entry in history) {
             val owner = entry.vehicle.owner
@@ -424,8 +423,8 @@ class ParkingHistoryService(
                 ParkingEventDTO(
                     id = entryId * 10,
                     plateNumber = entry.vehicle.licensePlate,
-                    eventType = "ENTRY",
-                    eventDate = entry.startTime.format(formatter),
+                    eventType = ParkingEventType.ENTRY,
+                    eventDate = entry.startTime,
                     ownerName = owner.name,
                     ownerSurname = owner.surname,
                     ownerEmail = owner.email,
@@ -438,8 +437,8 @@ class ParkingHistoryService(
                     ParkingEventDTO(
                         id = entryId * 10 + 1,
                         plateNumber = entry.vehicle.licensePlate,
-                        eventType = "EXIT",
-                        eventDate = entry.endTime!!.format(formatter),
+                        eventType = ParkingEventType.EXIT,
+                        eventDate = entry.endTime!!,
                         ownerName = owner.name,
                         ownerSurname = owner.surname,
                         ownerEmail = owner.email,
@@ -451,5 +450,4 @@ class ParkingHistoryService(
 
         return events.sortedByDescending { it.eventDate }
     }
-
 }


### PR DESCRIPTION
## 📝 Description
This PR introduces the `/api/parking-history/events` endpoint, designed to perfectly match the frontend `ParkingEventDTO` interface.

## Changes made
* **`ParkingEventDTO.kt`**: Created a new DTO containing flattened event details (`plateNumber`, `eventType` [ENTRY/EXIT], `eventDate`, owner info, and `carPhotoPath`).
* **`ParkingHistoryService.kt`**: Added the `getParkingEvents()` method. It iterates over the existing parking history and maps each session to an `ENTRY` event and, if an `endTime` is present, a corresponding `EXIT` event. The IDs are uniquely generated (`id * 10` for entries, `id * 10 + 1` for exits) to provide stable React keys on the frontend. The final list is sorted descending by date.
* **`ParkingHistoryController.kt`**: Exposed the mapping via the new `@GetMapping("/events")` endpoint, secured for users with the `ADMIN` role.

## How to test
1. Log in with an `ADMIN` account to obtain a Bearer token.
2. Ensure there is some data in the `parking_history` table (both completed and ongoing sessions).
3. Fetch the events:
`GET http://localhost:8080/api/parking-history/events`

## 🔗 Related Issue
Fixes #110 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.