### PR TITLE
User balance

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/testdata/TestDataGenerator.kt
+++ b/backend/src/main/kotlin/com/parkingplus/testdata/TestDataGenerator.kt
@@ -19,6 +19,7 @@ import com.parkingplus.transactions.enums.TransactionType
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.*
@@ -120,7 +121,8 @@ class TestDataGenerator(
                 password = passwordEncoder.encode("password123"),
                 isOperator = false,
                 isMfaEnabled = isMfaEnabled,
-                mfaSecret = mfaSecret
+                mfaSecret = mfaSecret,
+                balance = BigDecimal(Random.nextInt(50, 501))
             )
             users.add(userRepository.save(user))
         }

--- a/backend/src/main/kotlin/com/parkingplus/users/UserDTO.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserDTO.kt
@@ -2,6 +2,7 @@ package com.parkingplus.users
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import java.math.BigDecimal
 
 data class UserDTO(
     val id: Long? = null,
@@ -18,5 +19,7 @@ data class UserDTO(
 
     val isOperator: Boolean = false,
 
-    val isMfaEnabled: Boolean = false
+    val isMfaEnabled: Boolean = false,
+
+    val balance: BigDecimal = BigDecimal.ZERO
 )

--- a/backend/src/main/kotlin/com/parkingplus/users/UserEntity.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import java.time.Instant
+import java.math.BigDecimal
 
 @Entity
 @Table(name = "users")
@@ -41,5 +42,8 @@ class UserEntity(
     var mfaSecret: String? = null,
 
     @Column(name = "is_mfa_enabled", nullable = false)
-    var isMfaEnabled: Boolean = false
+    var isMfaEnabled: Boolean = false,
+
+    @Column(name = "balance", nullable = false)
+    var balance: BigDecimal = BigDecimal.ZERO
 )

--- a/backend/src/main/kotlin/com/parkingplus/users/UserEntity.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserEntity.kt
@@ -44,6 +44,6 @@ class UserEntity(
     @Column(name = "is_mfa_enabled", nullable = false)
     var isMfaEnabled: Boolean = false,
 
-    @Column(name = "balance", nullable = false)
+    @Column(name = "balance", nullable = false, precision = 19, scale = 2)
     var balance: BigDecimal = BigDecimal.ZERO
 )

--- a/backend/src/main/kotlin/com/parkingplus/users/UserMapper.kt
+++ b/backend/src/main/kotlin/com/parkingplus/users/UserMapper.kt
@@ -8,7 +8,8 @@ fun UserEntity.toDTO() = UserDTO(
     surname = surname,
     email = email,
     isOperator = isOperator,
-    isMfaEnabled = isMfaEnabled
+    isMfaEnabled = isMfaEnabled,
+    balance = balance
 )
 
 


### PR DESCRIPTION
## 📝 Description
Added user's balance and return the value in `/me` endpoint

### Changes Summary
* Data Model: Added a `balance` field (type `BigDecimal`) to the `UserEntity` class, mapped to the `users` table in the database.
* DTO & Mapping: Updated `UserDTO` to include the balance field and adjusted `UserMapper` to ensure the value is correctly passed from the entity to the API response.
* Endpoint `/me`: The `getCurrentUser` method in `UserController` now returns the user's current balance alongside other profile information.
* Test Data: Updated `TestDataGenerator` to assign a random initial balance (between 50 and 500) to all generated test users.

### Example
Endpoint: `GET /api/users/me`  

Header: `Authorization: Bearer <jwt_token>`

  Example Response:
```json
{
  "id": 42,
  "name": "Jan",
  "surname": "Kowalski",
  "email": "jan.kowalski@example.com",
  "isOperator": false,
  "isMfaEnabled": true,
  "balance": 345.50
}
```

## 🔗 Related Issue
Fixes #120 

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.