### PR TITLE
Purchase spot endpoint

### DIFF
--- a/backend/src/main/kotlin/com/parkingplus/reservations/PricingService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/PricingService.kt
@@ -18,21 +18,21 @@ class PricingService(
 
     fun calculateQuote(request: ParkingPurchaseRequestDTO, userId: Long): ParkingQuoteDTO {
         val price = calculatePrice(request.startTime, request.endTime)
-        
+
         val balanceToUse = if (request.vehicleId != null) {
-            val vehicle = vehicleRepository.findById(request.vehicleId).orElseThrow { 
-                NoSuchElementException("Vehicle with id ${request.vehicleId} not found") 
+            val vehicle = vehicleRepository.findById(request.vehicleId).orElseThrow {
+                NoSuchElementException("Vehicle with id ${request.vehicleId} not found")
             }
             vehicle.owner.balance
         } else {
-            val user = userRepository.findById(userId).orElseThrow { 
-                NoSuchElementException("User with id $userId not found") 
+            val user = userRepository.findById(userId).orElseThrow {
+                NoSuchElementException("User with id $userId not found")
             }
             user.balance
         }
-        
+
         val balanceAfter = balanceToUse.subtract(price)
-        
+
         return ParkingQuoteDTO(
             price = price,
             balanceAfter = balanceAfter
@@ -43,7 +43,7 @@ class PricingService(
         val durationMinutes = Duration.between(start, end).toMinutes()
         val durationHours = Math.ceil(durationMinutes / 60.0).toInt().coerceAtLeast(1)
         val dayOfWeek = start.dayOfWeek.value
-        
+
         val tariffs = tariffRepository.findAll()
         val dailyTariff = tariffs.find { it.isDaily && it.dayOfWeek == dayOfWeek }
 

--- a/backend/src/main/kotlin/com/parkingplus/reservations/ReservationController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/ReservationController.kt
@@ -9,7 +9,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/reservations")
 class ReservationController(
-    private val pricingService: PricingService
+    private val pricingService: PricingService,
+    private val reservationService: ReservationService
 ) {
 
     @PreAuthorize("isAuthenticated()")
@@ -18,14 +19,38 @@ class ReservationController(
         @RequestBody request: ParkingPurchaseRequestDTO,
         authentication: Authentication
     ): ResponseEntity<ParkingQuoteDTO> {
-        val authUserId = when (val details = authentication.details) {
+        val authUserId = extractUserId(authentication)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
+        val quote = pricingService.calculateQuote(request, authUserId)
+        return ResponseEntity.ok(quote)
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/purchase")
+    fun purchase(
+        @RequestBody request: ParkingPurchaseRequestDTO,
+        authentication: Authentication
+    ): ResponseEntity<ParkingPurchaseDTO> {
+        val authUserId = extractUserId(authentication)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
+        return try {
+            val result = reservationService.purchaseOrReserve(request, authUserId)
+            ResponseEntity.ok(result)
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
+        } catch (e: Exception) {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+
+    private fun extractUserId(authentication: Authentication): Long? {
+        return when (val details = authentication.details) {
             is Long -> details
             is Number -> details.toLong()
             is String -> details.toLongOrNull()
             else -> null
-        } ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-
-        val quote = pricingService.calculateQuote(request, authUserId)
-        return ResponseEntity.ok(quote)
+        }
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/reservations/ReservationService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/ReservationService.kt
@@ -1,0 +1,172 @@
+package com.parkingplus.reservations
+
+import com.parkingplus.parkinghistory.ParkingHistoryEntity
+import com.parkingplus.parkinghistory.ParkingHistoryRepository
+import com.parkingplus.parkingspaces.ParkingSpaceDTO
+import com.parkingplus.parkingspaces.ParkingSpaceRepository
+import com.parkingplus.parkingspaces.enums.ParkingSpaceStatus
+import com.parkingplus.parkingspaces.toDTO
+import com.parkingplus.transactions.TransactionEntity
+import com.parkingplus.transactions.TransactionRepository
+import com.parkingplus.transactions.enums.TransactionType
+import com.parkingplus.users.UserRepository
+import com.parkingplus.vehicles.VehicleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Service
+class ReservationService(
+    private val reservationRepository: ReservationRepository,
+    private val parkingSpaceRepository: ParkingSpaceRepository,
+    private val parkingHistoryRepository: ParkingHistoryRepository,
+    private val vehicleRepository: VehicleRepository,
+    private val userRepository: UserRepository,
+    private val transactionRepository: TransactionRepository,
+    private val pricingService: PricingService
+) {
+
+    @Transactional
+    fun purchaseOrReserve(request: ParkingPurchaseRequestDTO, userId: Long): ParkingPurchaseDTO {
+        val vehicleId = request.vehicleId ?: throw IllegalArgumentException("Vehicle ID is required")
+        val vehicle = vehicleRepository.findById(vehicleId)
+            .orElseThrow { NoSuchElementException("Vehicle with id $vehicleId not found") }
+
+        val user = vehicle.owner
+        val startTime = if (request.mode == "PURCHASE") LocalDateTime.now() else request.startTime
+        val endTime = request.endTime
+
+        if (endTime.isBefore(startTime)) {
+            throw IllegalArgumentException("End time must be after start time")
+        }
+
+        val price = pricingService.calculatePrice(startTime, endTime)
+
+        if (user.balance < price) {
+            throw IllegalStateException("Insufficient funds. Required: $price, available: ${user.balance}")
+        }
+
+        val allFreeSpaces = parkingSpaceRepository.findAllByStatus(ParkingSpaceStatus.FREE)
+        if (allFreeSpaces.isEmpty()) {
+            throw IllegalStateException("No available parking spaces")
+        }
+
+        val prioritySpaces = allFreeSpaces.filter { space ->
+            when (vehicle.carType) {
+                com.parkingplus.vehicles.enums.CarType.EV_HANDICAPED ->
+                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.EV_HANDICAPED ||
+                            space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.EV_BOTH
+
+                com.parkingplus.vehicles.enums.CarType.EV_ABLEBODIED ->
+                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.EV_ABLEBODIED
+
+                com.parkingplus.vehicles.enums.CarType.REGULAR_HANDICAPED ->
+                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_HANDICAPED ||
+                            space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_BOTH
+
+                else -> false
+            }
+        }
+
+        // If priority spaces exist, pick one randomly. 
+        // Otherwise, pick from available non-handicapped spaces if the vehicle is not eligible for handicapped spots.
+        val availableSpace = if (prioritySpaces.isNotEmpty()) {
+            prioritySpaces.shuffled().first()
+        } else {
+            // Fallback: If no priority space, pick a random free space.
+            // BUT: if it's an able-bodied person (regular or EV), avoid handicapped spaces even in fallback if possible.
+            val isEligibleForHandicapped = vehicle.carType == com.parkingplus.vehicles.enums.CarType.EV_HANDICAPED ||
+                    vehicle.carType == com.parkingplus.vehicles.enums.CarType.REGULAR_HANDICAPED
+
+            val fallbackPool = if (!isEligibleForHandicapped) {
+                val nonHandicappedSpaces = allFreeSpaces.filter {
+                    it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_HANDICAPED &&
+                            it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.EV_HANDICAPED &&
+                            it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_BOTH &&
+                            it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.EV_BOTH
+                }
+                if (nonHandicappedSpaces.isNotEmpty()) nonHandicappedSpaces else allFreeSpaces
+            } else {
+                allFreeSpaces
+            }
+
+            fallbackPool.shuffled().first()
+        }
+
+        // Deduct balance
+        user.balance = user.balance.subtract(price)
+        userRepository.save(user)
+
+        // Record transaction
+        transactionRepository.save(
+            TransactionEntity(
+                user = user,
+                type = TransactionType.WITHDRAWAL,
+                amount = price.toFloat(),
+                realisedAt = LocalDateTime.now()
+            )
+        )
+
+        val id: Long
+        if (request.mode == "PURCHASE") {
+            availableSpace.status = ParkingSpaceStatus.OCCUPIED
+            parkingSpaceRepository.save(availableSpace)
+
+            val history = parkingHistoryRepository.save(
+                ParkingHistoryEntity(
+                    vehicle = vehicle,
+                    parkingSpace = availableSpace,
+                    startTime = startTime,
+                    endTime = null, // Still occupied
+                    price = price.toDouble(),
+                    photoPath = "/photos/placeholder.jpg"
+                )
+            )
+            id = history.id ?: 0L
+        } else {
+            // Future reservation
+            // For now, we just mark the space as RESERVED if it's a reservation starting soon,
+            availableSpace.status = ParkingSpaceStatus.RESERVED
+            parkingSpaceRepository.save(availableSpace)
+
+            val reservation = reservationRepository.save(
+                ReservationEntity(
+                    user = user,
+                    vehicle = vehicle,
+                    parkingSpace = availableSpace,
+                    startTime = startTime,
+                    endTime = endTime,
+                    price = price,
+                    status = ReservationStatus.CONFIRMED
+                )
+            )
+            id = reservation.id ?: 0L
+        }
+
+        return ParkingPurchaseDTO(
+            id = id,
+            vehicleId = vehicleId,
+            licensePlate = vehicle.licensePlate,
+            mode = request.mode,
+            parkingSpace = availableSpace.toDTO(),
+            startTime = startTime,
+            endTime = endTime,
+            price = price,
+            balanceAfter = user.balance
+        )
+    }
+}
+
+data class ParkingPurchaseDTO(
+    val id: Long,
+    val vehicleId: Long,
+    val licensePlate: String,
+    val mode: String,
+    val parkingSpace: ParkingSpaceDTO,
+    val startTime: LocalDateTime,
+    val endTime: LocalDateTime,
+    val price: BigDecimal,
+    val balanceAfter: BigDecimal,
+    val currency: String = "PLN"
+)


### PR DESCRIPTION
## 📝 Description
Implemented purchase/reserve endpoint.

### Changes 
* Parking Purchase/Reservation Logic: Implemented ReservationService to handle the full flow of acquiring a parking spot. It manages balance verification, automated space allocation, and transaction recording.
* Smart Space Allocation: 
    * Priority System: Automatically prioritizes EV or handicapped spots based on the vehicle type.
    * Strict Access Control: Ensured that able-bodied drivers (even in EVs) do not occupy handicapped-specific spots (like EV_BOTH) during the priority search.
    * Randomized Selection: Among suitable spots, the system picks one at random to distribute parking load evenly.
    * Intelligent Fallback: If priority spots are unavailable, it selects a general spot, while still avoiding handicapped spots for non-eligible users whenever possible.
* Transaction Integration: Every purchase/reservation now triggers a WITHDRAWAL transaction and deducts the user's balance in a single atomic database operation.

### Example
Endpoint: `POST /api/reservations/purchase`
Header: `Authorization: Bearer <jwt_token>`

Request Body (JSON):
```json
{
  "vehicleId": 4,
  "mode": "RESERVATION",
  "startTime": "2026-05-13T12:00:00",
  "endTime": "2026-05-14T10:00:00"
}
```
Example Response (JSON):
```json
{
  "id": 15,
  "vehicleId": 4,
  "licensePlate": "KR 56789",
  "mode": "RESERVATION",
  "parkingSpace": {
    "id": "B12",
    "status": "RESERVED",
    "spaceType": "REGULAR_ABLEBODIED",
    "level": 1
  },
  "startTime": "2026-05-13T12:00:00",
  "endTime": "2026-05-14T10:00:00",
  "price": 45.50,
  "balanceAfter": 254.50,
  "currency": "PLN"
}
```

## 🔗 Related Issue
Fixes #122

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.