### PR TITLE
purchase spot endpoint

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -148,52 +148,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvmTarget>21</jvmTarget>
-                    <compilerPlugins>
-                        <plugin>spring</plugin>
-                        <plugin>jpa</plugin>
-                        <plugin>all-open</plugin>
-                    </compilerPlugins>
-                    <pluginOptions>
-                        <option>all-open:annotation=org.springframework.stereotype.Service</option>
-                        <option>all-open:annotation=org.springframework.stereotype.Repository</option>
-                        <option>all-open:annotation=org.springframework.transaction.annotation.Transactional</option>
-                    </pluginOptions>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-maven-allopen</artifactId>
-                        <version>${kotlin.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-maven-noarg</artifactId>
-                        <version>${kotlin.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
 

--- a/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkinghistory/ParkingHistoryRepository.kt
@@ -16,6 +16,7 @@ interface ParkingHistoryRepository : JpaRepository<ParkingHistoryEntity, Long> {
     fun existsByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): Boolean
     fun findAllByParkingSpaceId(parkingSpaceId: String): List<ParkingHistoryEntity>
     fun findByParkingSpaceIdAndEndTimeIsNull(parkingSpaceId: String): ParkingHistoryEntity?
+    fun existsByVehicleIdAndEndTimeIsNull(vehicleId: Long): Boolean
 
     @Query("SELECT COALESCE(SUM(p.price), 0.0) FROM ParkingHistoryEntity p WHERE p.endTime BETWEEN :start AND :end")
     fun sumPriceByEndTimeBetween(

--- a/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/parkingspaces/ParkingSpaceRepository.kt
@@ -4,12 +4,19 @@ import com.parkingplus.parkingspaces.enums.SpaceType
 import org.springframework.data.jpa.repository.JpaRepository
 import com.parkingplus.parkingspaces.enums.ParkingSpaceStatus
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.Lock
+import jakarta.persistence.LockModeType
 
 
 interface ParkingSpaceRepository : JpaRepository<ParkingSpaceEntity, String> {
     fun findAllByLevel(level: Int): List<ParkingSpaceEntity>
     fun findAllBySpaceType(spaceType: SpaceType): List<ParkingSpaceEntity>
     fun findAllByStatus(status: ParkingSpaceStatus): List<ParkingSpaceEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM ParkingSpaceEntity p WHERE p.status = :status")
+    fun findAllByStatusWithLock(status: ParkingSpaceStatus): List<ParkingSpaceEntity>
+
     fun findAllByLevelAndSpaceType(level: Int, spaceType: SpaceType): List<ParkingSpaceEntity>
 
     @Query("SELECT p.status, COUNT(p) FROM ParkingSpaceEntity p GROUP BY p.status")

--- a/backend/src/main/kotlin/com/parkingplus/reservations/PricingService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/PricingService.kt
@@ -18,14 +18,14 @@ class PricingService(
     private val vehicleRepository: VehicleRepository
 ) {
 
-    fun calculateQuote(request: ParkingPurchaseRequestDTO, userId: Long): ParkingQuoteDTO {
+    fun calculateQuote(request: ParkingPurchaseRequestDTO, userId: Long, isAdmin: Boolean = false): ParkingQuoteDTO {
         val price = calculatePrice(request.startTime, request.endTime)
         
         val balanceToUse = if (request.vehicleId != null) {
             val vehicle = vehicleRepository.findById(request.vehicleId).orElseThrow {
                 ResponseStatusException(HttpStatus.NOT_FOUND, "Vehicle with id ${request.vehicleId} not found")
             }
-            if (vehicle.owner.id != userId) {
+            if (!isAdmin && vehicle.owner.id != userId) {
                 throw ResponseStatusException(HttpStatus.FORBIDDEN, "Vehicle with id ${request.vehicleId} does not belong to user $userId")
             }
             vehicle.owner.balance
@@ -78,7 +78,7 @@ class PricingService(
             val tariff = if (isFirstHour) {
                 hourlyTariffs.find { it.isFirstHour } ?: hourlyTariffs.find { !it.isFirstHour }
             } else {
-                hourlyTariffs.find { !it.isFirstHour }
+                hourlyTariffs.find { !it.isFirstHour } ?: hourlyTariffs.find { it.isFirstHour }
             }
 
             val priceToAdd = if (tariff != null) BigDecimal.valueOf(tariff.price) else BigDecimal.valueOf(5.0)

--- a/backend/src/main/kotlin/com/parkingplus/reservations/ReservationController.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/ReservationController.kt
@@ -5,11 +5,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 @RequestMapping("/api/reservations")
 class ReservationController(
-    private val pricingService: PricingService
+    private val pricingService: PricingService,
+    private val reservationService: ReservationService
 ) {
 
     @PreAuthorize("hasAnyRole('ADMIN','CLIENT')")
@@ -18,14 +20,43 @@ class ReservationController(
         @RequestBody request: ParkingPurchaseRequestDTO,
         authentication: Authentication
     ): ResponseEntity<ParkingQuoteDTO> {
-        val authUserId = when (val details = authentication.details) {
+        val authUserId = extractUserId(authentication)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
+        val isAdmin = authentication.authorities.any { it.authority == "ROLE_ADMIN" }
+        val quote = pricingService.calculateQuote(request, authUserId, isAdmin)
+        return ResponseEntity.ok(quote)
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/purchase")
+    fun purchase(
+        @RequestBody request: ParkingPurchaseRequestDTO,
+        authentication: Authentication
+    ): ResponseEntity<ParkingPurchaseDTO> {
+        val authUserId = extractUserId(authentication)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
+        val isAdmin = authentication.authorities.any { it.authority == "ROLE_ADMIN" }
+
+        return try {
+            val result = reservationService.purchaseOrReserve(request, authUserId, isAdmin)
+            ResponseEntity.ok(result)
+        } catch (e: ResponseStatusException) {
+            throw e
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
+        } catch (e: Exception) {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+
+    private fun extractUserId(authentication: Authentication): Long? {
+        return when (val details = authentication.details) {
             is Long -> details
             is Number -> details.toLong()
             is String -> details.toLongOrNull()
             else -> null
-        } ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-
-        val quote = pricingService.calculateQuote(request, authUserId)
-        return ResponseEntity.ok(quote)
+        }
     }
 }

--- a/backend/src/main/kotlin/com/parkingplus/reservations/ReservationRepository.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/ReservationRepository.kt
@@ -2,6 +2,12 @@ package com.parkingplus.reservations
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 @Repository
-interface ReservationRepository : JpaRepository<ReservationEntity, Long>
+interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
+    @Query("SELECT r FROM ReservationEntity r WHERE r.parkingSpace.id = :spaceId AND r.status = 'CONFIRMED' AND " +
+           "(r.startTime < :endTime AND r.endTime > :startTime)")
+    fun findOverlappingReservations(spaceId: String, startTime: LocalDateTime, endTime: LocalDateTime): List<ReservationEntity>
+}

--- a/backend/src/main/kotlin/com/parkingplus/reservations/ReservationService.kt
+++ b/backend/src/main/kotlin/com/parkingplus/reservations/ReservationService.kt
@@ -5,12 +5,14 @@ import com.parkingplus.parkinghistory.ParkingHistoryRepository
 import com.parkingplus.parkingspaces.ParkingSpaceDTO
 import com.parkingplus.parkingspaces.ParkingSpaceRepository
 import com.parkingplus.parkingspaces.enums.ParkingSpaceStatus
+import com.parkingplus.parkingspaces.enums.SpaceType
 import com.parkingplus.parkingspaces.toDTO
 import com.parkingplus.transactions.TransactionEntity
 import com.parkingplus.transactions.TransactionRepository
 import com.parkingplus.transactions.enums.TransactionType
 import com.parkingplus.users.UserRepository
 import com.parkingplus.vehicles.VehicleRepository
+import com.parkingplus.vehicles.enums.CarType
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,14 +32,25 @@ class ReservationService(
 ) {
 
     @Transactional
-    fun purchaseOrReserve(request: ParkingPurchaseRequestDTO, userId: Long): ParkingPurchaseDTO {
+    fun purchaseOrReserve(request: ParkingPurchaseRequestDTO, userId: Long, isAdmin: Boolean = false): ParkingPurchaseDTO {
         val vehicleId = request.vehicleId ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Vehicle ID is required")
         val vehicle = vehicleRepository.findById(vehicleId)
             .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Vehicle with id $vehicleId not found") }
         
+        // Security: Verify ownership or admin override
+        if (!isAdmin && vehicle.owner.id != userId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Vehicle with id $vehicleId does not belong to user $userId")
+        }
+
+        // Duplicate Check: Ensure vehicle doesn't already have an active stay
+        if (parkingHistoryRepository.existsByVehicleIdAndEndTimeIsNull(vehicleId)) {
+            throw ResponseStatusException(HttpStatus.CONFLICT, "Vehicle already has an active parking stay")
+        }
+        
         val user = vehicle.owner
+        val duration = java.time.Duration.between(request.startTime, request.endTime)
         val startTime = if (request.mode == ParkingPurchaseMode.PURCHASE) LocalDateTime.now() else request.startTime
-        val endTime = request.endTime
+        val endTime = if (request.mode == ParkingPurchaseMode.PURCHASE) startTime.plus(duration) else request.endTime
 
         val price = pricingService.calculatePrice(startTime, endTime)
         
@@ -45,53 +58,66 @@ class ReservationService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Insufficient funds. Required: $price, available: ${user.balance}")
         }
 
-        // Find an available parking space
-        val allFreeSpaces = parkingSpaceRepository.findAllByStatus(ParkingSpaceStatus.FREE)
-        if (allFreeSpaces.isEmpty()) {
-            throw ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "No available parking spaces")
+        // Find available parking spaces with pessimistic lock for atomicity
+        val allFreeSpaces = parkingSpaceRepository.findAllByStatusWithLock(ParkingSpaceStatus.FREE)
+        
+        // Filter out spaces that have overlapping reservations
+        val trulyAvailableSpaces = allFreeSpaces.filter { space ->
+            reservationRepository.findOverlappingReservations(space.id, startTime, endTime).isEmpty()
         }
 
-        // Filter for priority spaces based on vehicle type
-        val prioritySpaces = allFreeSpaces.filter { space ->
+        if (trulyAvailableSpaces.isEmpty()) {
+            throw ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "No available parking spaces for the selected time range")
+        }
+
+        // SMART ALLOCATION LOGIC
+        
+        // 1. Priority search: EV or handicapped spots based on vehicle type
+        val prioritySpaces = trulyAvailableSpaces.filter { space ->
             when (vehicle.carType) {
-                com.parkingplus.vehicles.enums.CarType.EV_HANDICAPED -> 
-                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.EV_HANDICAPED || 
-                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.EV_BOTH
+                CarType.EV_HANDICAPED -> 
+                    space.spaceType == SpaceType.EV_HANDICAPED || 
+                    space.spaceType == SpaceType.EV_BOTH
                 
-                com.parkingplus.vehicles.enums.CarType.EV_ABLEBODIED -> 
-                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.EV_ABLEBODIED
+                CarType.EV_ABLEBODIED -> 
+                    space.spaceType == SpaceType.EV_ABLEBODIED
                 
-                com.parkingplus.vehicles.enums.CarType.REGULAR_HANDICAPED -> 
-                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_HANDICAPED || 
-                    space.spaceType == com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_BOTH
+                CarType.REGULAR_HANDICAPED -> 
+                    space.spaceType == SpaceType.REGULAR_HANDICAPED || 
+                    space.spaceType == SpaceType.REGULAR_BOTH
                 
                 else -> false
             }
         }
 
-        // If priority spaces exist, pick one randomly. 
-        // Otherwise, pick from available non-handicapped spaces if the vehicle is not eligible for handicapped spots.
+        // 2. randomized selection if priority spots exist
         val availableSpace = if (prioritySpaces.isNotEmpty()) {
             prioritySpaces.shuffled().first()
         } else {
-            val isEligibleForHandicapped = vehicle.carType == com.parkingplus.vehicles.enums.CarType.EV_HANDICAPED || 
-                                           vehicle.carType == com.parkingplus.vehicles.enums.CarType.REGULAR_HANDICAPED
+            // 3. Intelligent Fallback: pick a general spot, but strictly avoid handicapped spots for non-eligible users
+            val isEligibleForHandicapped = vehicle.carType == CarType.EV_HANDICAPED || 
+                                           vehicle.carType == CarType.REGULAR_HANDICAPED
             
             val fallbackPool = if (!isEligibleForHandicapped) {
-                val nonHandicappedSpaces = allFreeSpaces.filter { 
-                    it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_HANDICAPED &&
-                    it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.EV_HANDICAPED &&
-                    it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.REGULAR_BOTH &&
-                    it.spaceType != com.parkingplus.parkingspaces.enums.SpaceType.EV_BOTH
+                trulyAvailableSpaces.filter { 
+                    it.spaceType != SpaceType.REGULAR_HANDICAPED &&
+                    it.spaceType != SpaceType.EV_HANDICAPED &&
+                    it.spaceType != SpaceType.REGULAR_BOTH &&
+                    it.spaceType != SpaceType.EV_BOTH
                 }
-                if (nonHandicappedSpaces.isNotEmpty()) nonHandicappedSpaces else allFreeSpaces
             } else {
-                allFreeSpaces
+                trulyAvailableSpaces
+            }
+
+            if (fallbackPool.isEmpty()) {
+                throw ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "No suitable parking spaces available for this vehicle type")
             }
             
             fallbackPool.shuffled().first()
         }
 
+        // TRANSACTION INTEGRATION (Atomic Operation)
+        
         // Deduct balance
         user.balance = user.balance.subtract(price)
         userRepository.save(user)
@@ -107,9 +133,7 @@ class ReservationService(
         )
 
         val id: Long
-        val finalMode: String
         if (request.mode == ParkingPurchaseMode.PURCHASE) {
-            finalMode = "PURCHASE"
             availableSpace.status = ParkingSpaceStatus.OCCUPIED
             parkingSpaceRepository.save(availableSpace)
 
@@ -118,17 +142,14 @@ class ReservationService(
                     vehicle = vehicle,
                     parkingSpace = availableSpace,
                     startTime = startTime,
-                    endTime = null,
+                    endTime = endTime, // Persist planned end time
                     price = price.toDouble(),
                     photoPath = "/photos/placeholder.jpg"
                 )
             )
-            id = history.id ?: 0L
+            id = history.id ?: throw IllegalStateException("Failed to save parking history ID")
         } else {
-            finalMode = "RESERVATION"
-            availableSpace.status = ParkingSpaceStatus.RESERVED
-            parkingSpaceRepository.save(availableSpace)
-
+            // Reservations DO NOT change immediate space status to OCCUPIED
             val reservation = reservationRepository.save(
                 ReservationEntity(
                     user = user,
@@ -140,14 +161,14 @@ class ReservationService(
                     status = ReservationStatus.CONFIRMED
                 )
             )
-            id = reservation.id ?: 0L
+            id = reservation.id ?: throw IllegalStateException("Failed to save reservation ID")
         }
 
         return ParkingPurchaseDTO(
             id = id,
             vehicleId = vehicleId,
             licensePlate = vehicle.licensePlate,
-            mode = finalMode,
+            mode = request.mode.name,
             parkingSpace = availableSpace.toDTO(),
             startTime = startTime,
             endTime = endTime,


### PR DESCRIPTION
## 📝 Description
Implemented purchase/reserve endpoint.

### Changes 
* Parking Purchase/Reservation Logic: Implemented ReservationService to handle the full flow of acquiring a parking spot. It manages balance verification, automated space allocation, and transaction recording.
* Smart Space Allocation: 
    * Priority System: Automatically prioritizes EV or handicapped spots based on the vehicle type.
    * Strict Access Control: Ensured that able-bodied drivers (even in EVs) do not occupy handicapped-specific spots (like EV_BOTH) during the priority search.
    * Randomized Selection: Among suitable spots, the system picks one at random to distribute parking load evenly.
    * Intelligent Fallback: If priority spots are unavailable, it selects a general spot, while still avoiding handicapped spots for non-eligible users whenever possible.
* Transaction Integration: Every purchase/reservation now triggers a WITHDRAWAL transaction and deducts the user's balance in a single atomic database operation.

### Example
Endpoint: `POST /api/reservations/purchase`
Header: `Authorization: Bearer <jwt_token>`

Request Body (JSON):
```json
{
  "vehicleId": 4,
  "mode": "RESERVATION",
  "startTime": "2026-05-13T12:00:00",
  "endTime": "2026-05-14T10:00:00"
}
```
Example Response (JSON):
```json
{
  "id": 15,
  "vehicleId": 4,
  "licensePlate": "KR 56789",
  "mode": "RESERVATION",
  "parkingSpace": {
    "id": "B12",
    "status": "RESERVED",
    "spaceType": "REGULAR_ABLEBODIED",
    "level": 1
  },
  "startTime": "2026-05-13T12:00:00",
  "endTime": "2026-05-14T10:00:00",
  "price": 45.50,
  "balanceAfter": 254.50,
  "currency": "PLN"
}
```

## 🔗 Related Issue
Fixes #122

## 🛠️ Type of change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring / Code cleanup
- [ ] 📚 Documentation update

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have added tests for my changes (if applicable).
- [ ] Documentation has been updated.
- [x] The code builds locally without any errors.